### PR TITLE
Made imageAnchorCreated public

### DIFF
--- a/SumerianARCoreStarter/app/src/main/java/com/amazon/sumerianarcorestarter/SumerianConnector.java
+++ b/SumerianARCoreStarter/app/src/main/java/com/amazon/sumerianarcorestarter/SumerianConnector.java
@@ -112,7 +112,7 @@ class SumerianConnector {
         }
     }
 
-    private void imageAnchorCreated(AugmentedImage augmentedImage) {
+    void imageAnchorCreated(AugmentedImage augmentedImage) {
         final float[] imageAnchorPoseMatrix = new float[16];
         augmentedImage.getCenterPose().toMatrix(imageAnchorPoseMatrix, 0);
         final String imageAnchorResponseScript = "ARCoreBridge.imageAnchorResponse('" +


### PR DESCRIPTION
This function should be public so it can be accessed in MainActivity, specifically the onDrawFrame function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
