### PR TITLE
Add specific required feature for AR camera as required for Google Play Store Submissions

### DIFF
--- a/SumerianARCoreStarter/app/src/main/AndroidManifest.xml
+++ b/SumerianARCoreStarter/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.amazon.sumerianarcorestarter">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature android:name="android.hardware.camera.ar" android:required="true" />
+	
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -19,7 +23,4 @@
         <meta-data android:name="com.google.ar.core" android:value="required" />
     </application>
 
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.CAMERA" />
-    <uses-feature android:name="android.hardware.camera" />
 </manifest>


### PR DESCRIPTION
*Description of changes:*

Submitting an app to the Google Play Store based on the original starter app fails with the following message:

> "The uses-feature android.hardware.camera.ar is required in in the AndroidManifest.xml file when a dependency on ARCore is specified as required."

This commit adds the required line to the manifest to fix the error. Additionally, I moved the dependencies before the <application> element, as recommended by Android Studio.

An ARCore-based Amazon Sumerian app that I submitted to the Play Store was allowed to go live with these changes. For reference: you can check how the dependencies are shown and that the app is only available on ARCore enabled phones as intended in the [app store listing](https://play.google.com/store/apps/details?id=com.andreasjakl.dhcexplained).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.